### PR TITLE
fix: quote job name to avoid YAML anchor parse error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   unit-integration:
-    name: Unit & Integration (Linux)
+    name: "Unit and Integration (Linux)"
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
'&' in plain scalar triggers GitHub Actions YAML parser bug, causing silent 'Error:' at Set up job step.